### PR TITLE
Update new import paths for nats.go

### DIFF
--- a/examples/publish/main.go
+++ b/examples/publish/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The NATS Authors
+// Copyright 2019-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/not.go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"

--- a/examples/reply/main.go
+++ b/examples/reply/main.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/not.go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"

--- a/examples/request/main.go
+++ b/examples/request/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/not.go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"

--- a/examples/subscribe/main.go
+++ b/examples/subscribe/main.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/not.go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"

--- a/not.go
+++ b/not.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-lib/metrics"
 

--- a/scripts/start_jaeger.sh
+++ b/scripts/start_jaeger.sh
@@ -10,4 +10,3 @@ docker run -d --name jaeger \
   -p 14268:14268 \
   -p 9411:9411 \
   jaegertracing/all-in-one:1.9
-


### PR DESCRIPTION
Reference to #1 to fix the nats.go path reference on the import statements for not.go and the examples.